### PR TITLE
feat: Add game options for result saving and replaying questions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -327,6 +327,17 @@ const AppIniziale: React.FC<AppInizialeProps> = ({ email, userGlobalLevel, onRet
     return userGlobalLevel || localStorage.getItem('livello') || 'B1';
   });
 
+  // Nuovi stati per le opzioni globali
+  const [saveResultsGlobally, setSaveResultsGlobally] = useState<boolean>(() => {
+    const item = localStorage.getItem('saveResultsGlobally');
+    return item ? JSON.parse(item) : true; // Default a true
+  });
+
+  const [includeAnsweredQuestions, setIncludeAnsweredQuestions] = useState<boolean>(() => {
+    const item = localStorage.getItem('includeAnsweredQuestions');
+    return item ? JSON.parse(item) : false; // Default a false
+  });
+
   const [usuarioActividad, setUsuarioActividad] = useState<Usuario | null>(null);
 
   useEffect(() => {
@@ -362,6 +373,15 @@ const AppIniziale: React.FC<AppInizialeProps> = ({ email, userGlobalLevel, onRet
     // Save current 'livello' selection to localStorage
     localStorage.setItem('livello', livello);
   }, [livello]);
+
+  // useEffect per salvare i nuovi stati in localStorage
+  useEffect(() => {
+    localStorage.setItem('saveResultsGlobally', JSON.stringify(saveResultsGlobally));
+  }, [saveResultsGlobally]);
+
+  useEffect(() => {
+    localStorage.setItem('includeAnsweredQuestions', JSON.stringify(includeAnsweredQuestions));
+  }, [includeAnsweredQuestions]);
 
   const [componenteSelezionato, setComponenteSelezionato] = useState<string | null>(null);
 
@@ -444,24 +464,67 @@ const AppIniziale: React.FC<AppInizialeProps> = ({ email, userGlobalLevel, onRet
     setComponenteSelezionato(componente);
   };
 
+  const handleGoToMainMenu = () => {
+    setComponenteSelezionato(null);
+  };
+
   if (componenteSelezionato === 'quiz') {
-    return <QuizItaliano numQuestions={ numDomande } name = { nome } onlyOptionQuestions = { soloOpzioni } difficulty = { livello } usuario = { usuarioActividad } />;
+    return <QuizItaliano
+            numQuestions={numDomande}
+            name={nome}
+            onlyOptionQuestions={soloOpzioni}
+            difficulty={livello}
+            usuario={usuarioActividad}
+            onExit={handleGoToMainMenu}
+            saveResults={saveResultsGlobally}
+            includePreviouslyAnswered={includeAnsweredQuestions}
+            />;
   }
 
   if (componenteSelezionato === 'learning') {
-    return <ItalianLearningApp numQuestions={ numDomande } name = { nome } onlyOptionQuestions = { soloOpzioni } difficulty = { livello } usuario = { usuarioActividad } />;
+    return <ItalianLearningApp
+            numQuestions={numDomande}
+            name={nome}
+            onlyOptionQuestions={soloOpzioni}
+            difficulty={livello}
+            usuario={usuarioActividad}
+            onExit={handleGoToMainMenu}
+            saveResults={saveResultsGlobally}
+            includePreviouslyAnswered={includeAnsweredQuestions}
+            />;
   }
   if (componenteSelezionato === 'estad') {
+    // Nota: EstadisticasRespuestas potrebbe non aver bisogno di un pulsante "Esci" diretto se è inteso come una schermata veloce.
+    // Se necessario, si può aggiungere onExit anche qui. Per ora, lo lascio com'è.
     return <EstadisticasRespuestas idUsuario={usuarioActividad?.id??'sense'} />;
   }
   if (componenteSelezionato === 'impiccato') {
-     return <HangmanGame usuario={usuarioActividad} />; 
+     return <HangmanGame
+            usuario={usuarioActividad}
+            onExit={handleGoToMainMenu}
+            saveResults={saveResultsGlobally} // Anche se impiccato non salva sessioni, la prop potrebbe servire per coerenza o future necessità
+            includePreviouslyAnswered={includeAnsweredQuestions}
+            difficulty={livello} // Passiamo anche difficulty se serve per filtrare le parole
+            />;
   }
   if (componenteSelezionato === 'error') {
-    return <ItalianErrorDetectionGame level={livello} />;
+    return <ItalianErrorDetectionGame
+            level={livello}
+            usuario={usuarioActividad}
+            onExit={handleGoToMainMenu}
+            saveResults={saveResultsGlobally}
+            includePreviouslyAnswered={includeAnsweredQuestions}
+            />;
   }
   if (componenteSelezionato === 'typing') {
-    return <ItalianTypingTutor />
+    // Typing tutor non ha un concetto di "domande già risposte" allo stesso modo,
+    // ma passiamo le props per coerenza e per il salvataggio.
+    return <ItalianTypingTutor
+            usuario={usuarioActividad}
+            onExit={handleGoToMainMenu}
+            saveResults={saveResultsGlobally}
+            // includePreviouslyAnswered non molto rilevante qui
+            />;
   }
   return (
     <Card className= "w-full max-w-md mx-auto bg-gradient-to-r from-blue-100 to-green-100" >
@@ -528,8 +591,46 @@ label = {
       </span>
       </div>
           }
-className = "mb-4"
+className = "mb-2" // Ridotto mb per fare spazio
   />
+   <FormControlLabel
+            control={
+              <Checkbox
+                checked={saveResultsGlobally}
+                onChange={(e) => setSaveResultsGlobally(e.target.checked)}
+                name="saveResultsGlobally"
+                color="primary"
+              />
+            }
+            label={
+              <div className="flex items-center">
+                Salva risultati sessione
+                <span className="ml-2 cursor-pointer" title="Se deselezionato, i risultati di questa sessione non verranno salvati su Firebase.">
+                  ℹ️
+                </span>
+              </div>
+            }
+            className="mb-2"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                checked={includeAnsweredQuestions}
+                onChange={(e) => setIncludeAnsweredQuestions(e.target.checked)}
+                name="includeAnsweredQuestions"
+                color="primary"
+              />
+            }
+            label={
+              <div className="flex items-center">
+                Includi domande già risposte
+                <span className="ml-2 cursor-pointer" title="Se selezionato, le domande a cui hai già risposto in passato potrebbero riapparire.">
+                  ℹ️
+                </span>
+              </div>
+            }
+            className="mb-4"
+          />
   <Button onClick={ () => handleStart('quiz') } className = "w-full bg-blue-500 hover:bg-blue-700 text-white mb-2" >
     Quiz a Scelta Multipla
       </Button>

--- a/src/ItalianTypingTutor.tsx
+++ b/src/ItalianTypingTutor.tsx
@@ -3,7 +3,8 @@ import { Input, Button } from "@mui/material"
 import { Card, CardContent, CardHeader, Typography  } from "@mui/material"
 import { Table, TableBody, TableCell, TableHead, TableRow } from "@mui/material"
 import { RegTyping } from './MyTypes';
-import { fetchTyping } from './firebase/firebaseFunctions';
+import { fetchTyping, saveGameSessionResult } from './firebase/firebaseFunctions'; // Importato saveGameSessionResult
+import { Usuario, GameSessionResult } from './firebase/firebaseInterfaces'; // Importato Usuario e GameSessionResult
 //import italianPhrases from '@/italian_phrases.json'
 
 type Lesson = {
@@ -20,7 +21,14 @@ type Result = {
   realAccuracy: number;
 };
 
-export default function ItalianTypingTutor() {
+interface ItalianTypingTutorProps {
+  onExit?: () => void;
+  usuario?: Usuario | null;
+  saveResults?: boolean;
+  includePreviouslyAnswered?: boolean; // Generalmente non applicabile al typing tutor in termini di "testi già digitati"
+}
+
+export default function ItalianTypingTutor({ onExit, usuario, saveResults, includePreviouslyAnswered }: ItalianTypingTutorProps) {
   const [lessons, setLessons] = useState<Lesson[]>([]);
   const [currentLessonIndex, setCurrentLessonIndex] = useState(0);
   const [input, setInput] = useState('');
@@ -113,6 +121,9 @@ export default function ItalianTypingTutor() {
   };
 
   const finishExercise = () => {
+    if (results.length > 0) {
+      saveTypingSessionResults(); // Salva prima di mostrare i risultati
+    }
     setShowResults(true);
   };
 
@@ -125,11 +136,60 @@ export default function ItalianTypingTutor() {
     resetLesson();
   };
 
+  const saveTypingSessionResults = () => {
+    if (!saveResults) {
+        console.log("Salvataggio sessione Dattilografia saltato per scelta dell'utente.");
+        return;
+    }
+    if (!usuario || !usuario.id || results.length === 0) {
+      console.log("Salvataggio sessione Dattilografia: Utente non loggato o nessun risultato da salvare.");
+      return;
+    }
+
+    const averageWpm = results.reduce((acc, r) => acc + r.wpm, 0) / results.length;
+    const averageAccuracy = results.reduce((acc, r) => acc + r.accuracy, 0) / results.length;
+    const averageRealAccuracy = results.reduce((acc, r) => acc + r.realAccuracy, 0) / results.length;
+    // Il livello e il tema potrebbero variare se le lezioni sono miste.
+    // Per semplicità, prendiamo il tema e il livello della prima lezione completata o dell'ultima.
+    // Oppure si potrebbe decidere di non salvare un tema/livello specifico per la sessione aggregata.
+    const representativeTheme = results[0]?.theme || 'Misto';
+    const representativeLevel = results[0]?.level || 'Misto';
+
+
+    const gameSession: GameSessionResult = {
+      userId: usuario.id,
+      gameType: 'TypingTutor',
+      timestamp: new Date(), // Sarà sovrascritto dal serverTimestamp
+      difficulty: representativeLevel, // O un modo per determinare il livello generale
+      itemsPlayed: results.length, // Numero di frasi completate
+      gameSpecificDetails: {
+        wpm: Math.round(averageWpm),
+        accuracy: Math.round(averageAccuracy),
+        realAccuracy: Math.round(averageRealAccuracy),
+        theme: representativeTheme,
+        // Potremmo anche salvare tutti i risultati individuali se necessario
+        // individualResults: results
+      }
+    };
+    saveGameSessionResult(gameSession);
+    console.log("Risultati sessione Dattilografia inviati a Firebase:", gameSession);
+  };
+
+  const handleExitRequest = () => {
+    // Salva solo se ci sono risultati E non sono ancora stati mostrati/salvati tramite finishExercise
+    if (results.length > 0 && !showResults) {
+      saveTypingSessionResults();
+    }
+    if (onExit) {
+      onExit();
+    }
+  };
+
   if (showResults) {
+    // I risultati sono già stati salvati da finishExercise, quindi non serve salvarli di nuovo qui.
     return (
       <Card className="w-full max-w-3xl mx-auto">
-        <CardHeader title="Risultati dell'Esercizio">
-        </CardHeader>
+        <CardHeader title="Risultati dell'Esercizio" />
         <CardContent>
           <Table>
             <TableHead>
@@ -153,7 +213,12 @@ export default function ItalianTypingTutor() {
               ))}
             </TableBody>
           </Table>
-          <Button onClick={restartExercise} className="mt-4">Ricomincia Esercizio</Button>
+          <Button onClick={restartExercise} className="mt-4" sx={{ mr: 1 }}>Ricomincia Esercizio</Button>
+          {onExit && (
+            <Button onClick={handleExitRequest} className="mt-4" variant="contained" color="secondary">
+              Torna al Menu Principale
+            </Button>
+          )}
         </CardContent>
       </Card>
     );
@@ -166,6 +231,13 @@ export default function ItalianTypingTutor() {
           <Typography variant="h6">
             Dattilografia Italiano - {lessons[currentLessonIndex]?.theme} (Nivel {lessons[currentLessonIndex]?.level})
           </Typography>
+        }
+        action={
+          onExit && !isCompleted && (
+            <Button onClick={handleExitRequest} variant="outlined" size="small">
+              Esci
+            </Button>
+          )
         }
       />      
       <CardContent>
@@ -194,7 +266,12 @@ export default function ItalianTypingTutor() {
             <div className="space-x-2">
               <Button onClick={repeatLesson}>Ripeti frase</Button>
               <Button onClick={nextLesson}>Lezione successiva</Button>
-              <Button onClick={finishExercise}>Termina esercizio</Button>
+              <Button onClick={finishExercise} sx={{ mr: 1 }}>Termina esercizio e Vedi Risultati</Button>
+              {onExit && (
+                <Button onClick={onExit} variant="contained" color="secondary" size="small">
+                  Torna al Menu
+                </Button>
+              )}
             </div>
           </div>
         )}

--- a/src/MyTypes.tsx
+++ b/src/MyTypes.tsx
@@ -54,6 +54,9 @@ export interface QuizParams {
     onlyOptionQuestions?: boolean;
     difficulty?: string;
     usuario: Usuario | null;
+    onExit?: () => void; // Funzione per tornare al menu principale
+    saveResults?: boolean; // Opzione per salvare i risultati della sessione
+    includePreviouslyAnswered?: boolean; // Opzione per includere domande già risposte
     
 }
 

--- a/src/QuizItalianoGPT.tsx
+++ b/src/QuizItalianoGPT.tsx
@@ -18,11 +18,12 @@ import { Question, QuizParams } from './MyTypes.js'
 import QuizQuestion from './components/Question'
 //import FormControlLabel from '@mui/material/FormControlLabel';
 //import Checkbox from '@mui/material/Checkbox';
-import { Respuesta } from './firebase/firebaseInterfaces';
-import { guardarRespuesta, fetchRespuestas, fetchMultiRespuesta } from './firebase/firebaseFunctions';
+import { Respuesta, GameSessionResult } from './firebase/firebaseInterfaces'; // Aggiunto GameSessionResult
+import { guardarRespuesta, fetchRespuestas, fetchMultiRespuesta, saveGameSessionResult } from './firebase/firebaseFunctions'; // Aggiunto saveGameSessionResult
 //import logo from './logo.jpg'; // Ajusta la ruta según la ubicación de tu imagen
+import { fetchAnsweredQuestionIdsGroupedByType } from './firebase/firebaseFunctions'; // Importa la nuova funzione
 
-let allQuestions: Question[] = [];// parseCSV(questionsCSV);
+let allQuestionsFromFile: Question[] = []; // Rinomina per chiarezza, queste sono tutte le domande dal file/DB grezzo
 
 
 const QuizItaliano: React.FC<QuizParams> = ({
@@ -30,7 +31,10 @@ const QuizItaliano: React.FC<QuizParams> = ({
     name = 'anonymous',
     onlyOptionQuestions = false,
     difficulty = 'B1',
-    usuario = null
+    usuario = null,
+    onExit,
+    saveResults = true,
+    includePreviouslyAnswered = false
 }) => {        
     const [currentQuestion, setCurrentQuestion] = useState(0);
     const [score, setScore] = useState(0);
@@ -38,152 +42,192 @@ const QuizItaliano: React.FC<QuizParams> = ({
     const [selectedAnswer, setSelectedAnswer] = useState<string | number | null>(null);
     const [quizFinished, setQuizFinished] = useState(false);   
     const [timer, setTimer] = useState(30);
-    const [questions, setQuestions] = useState<Question[]>([]);
+    const [questionsForSession, setQuestionsForSession] = useState<Question[]>([]); // Domande per la sessione corrente
     const [userAnswers, setUserAnswers] = useState<(string | number | null)[]>([]);
     const [reviewMode, setReviewMode] = useState(false);
     const [startTime, setStartTime] = useState<number | undefined>(undefined);
     const [endTime, setEndTime] = useState<number | undefined>(undefined);     
-    const [respuestas, setRespuestas] = useState<Respuesta[]>([]);
-    const [preguntasQuedan, setPreguntasQuedan] = useState(0);
-    const [loading, setLoading] = useState(false);
+    // const [respuestas, setRespuestas] = useState<Respuesta[]>([]); // Non più necessario, useremo answeredQuestionIdsByType
+
+    const [loading, setLoading] = useState(true); // Unico stato di loading
     const [error, setError] = useState<string | null>(null);
+
+    // Conteggi per l'UI
+    const [totalQuestionsInFile, setTotalQuestionsInFile] = useState(0);
+    const [possibleQuestionsForCriteria, setPossibleQuestionsForCriteria] = useState(0);
+    const [answeredQuestionsForCriteriaCount, setAnsweredQuestionsForCriteriaCount] = useState(0);
+    const [questionsAvailableToPlay, setQuestionsAvailableToPlay] = useState(0);
+
+
     useEffect(() => {
-        const loadWords = async () => {
+        const loadAllData = async () => {
+            setLoading(true);
+            setError(null);
             try {
-                setLoading(true);
-                const fetchedWords = await fetchMultiRespuesta();
-                allQuestions = fetchedWords;
-                setError(null);
+                // 1. Carica tutte le domande dal file/DB
+                if (allQuestionsFromFile.length === 0) { // Carica solo se non già presenti
+                    const fetchedQuestions = await fetchMultiRespuesta();
+                    allQuestionsFromFile = fetchedQuestions;
+                    setTotalQuestionsInFile(fetchedQuestions.length);
+                }
+
+                // 2. Recupera ID delle domande già risposte dall'utente
+                let answeredIdsSet = new Set<string>();
+                if (usuario?.id && process.env.REACT_APP_USE_DATABASE === 'true') {
+                    const answeredMap = await fetchAnsweredQuestionIdsGroupedByType(usuario.id);
+                    answeredIdsSet = answeredMap['MC'] || new Set<string>(); // 'MC' per Multiple Choice
+                }
+
+                // 3. Filtra le domande per difficoltà e tipo (onlyOptionQuestions)
+                const questionsMatchingCriteria = allQuestionsFromFile.filter(q => {
+                    const difficultyMatch = q.difficulty === difficulty;
+                    const typeMatch = !onlyOptionQuestions || Number(q.correct) !== -1;
+                    return difficultyMatch && typeMatch;
+                });
+                setPossibleQuestionsForCriteria(questionsMatchingCriteria.length);
+
+                // 4. Calcola quante di queste sono già state risposte
+                const answeredAmongCriteria = questionsMatchingCriteria.filter(q => answeredIdsSet.has(q.id.toString()));
+                setAnsweredQuestionsForCriteriaCount(answeredAmongCriteria.length);
+
+                // 5. Determina il pool di domande da cui scegliere per la sessione
+                let poolForSession: Question[];
+                if (includePreviouslyAnswered) {
+                    poolForSession = [...questionsMatchingCriteria];
+                } else {
+                    poolForSession = questionsMatchingCriteria.filter(q => !answeredIdsSet.has(q.id.toString()));
+                }
+                setQuestionsAvailableToPlay(poolForSession.length);
+
+                // 6. Seleziona le domande per la sessione corrente
+                const shuffledPool = poolForSession.sort(() => 0.5 - Math.random());
+                const sessionQuestions = shuffledPool.slice(0, numQuestions ?? 3);
+                setQuestionsForSession(sessionQuestions);
+
+                if (sessionQuestions.length === 0 && poolForSession.length > 0 && numQuestions > 0) {
+                    // Questo caso non dovrebbe succedere se numQuestions è ragionevole
+                    console.warn("Non sono state selezionate domande per la sessione nonostante ci fossero domande disponibili nel pool.");
+                }
+
+
+                setStartTime(Date.now());
+                setUserAnswers(new Array(sessionQuestions.length).fill(null));
+                setCurrentQuestion(0); // Resetta la domanda corrente
+                setScore(0); // Resetta lo score
+                setShowExplanation(false);
+                setSelectedAnswer(null);
+                setQuizFinished(false);
+
             } catch (err) {
-                setError('Error al cargar las palabras. Por favor, intenta de nuevo.');
-                console.error('Error fetching words:', err);
+                console.error('Errore durante il caricamento dei dati per QuizItalianoGPT:', err);
+                setError('Errore nel caricamento delle domande. Riprova.');
             } finally {
                 setLoading(false);
             }
         };
 
-        loadWords();
-    }, []);
-    useEffect(() => {
-        const loadRespuestas = async () => {
-            try {
-                const respuestasData = await fetchRespuestas(usuario?.id ?? 'sense');
-                setRespuestas(respuestasData);
-            } catch (error) {
-                console.error("Error al cargar respuestas:", error);
-            }
-        };
-        loadRespuestas();
-    }, [usuario]);
+        loadAllData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [numQuestions, difficulty, onlyOptionQuestions, includePreviouslyAnswered, usuario?.id]); // Ricarica se questi parametri cambiano
 
-    useEffect(() => {
-        let respuestasIds = [""];
-        if (respuestas.length > 0) {
-            // Filtrar las preguntas que ya han sido respondidas
-            respuestasIds = respuestas.map(r => r.idPregunta);            
-        }
-        
-        const filteredQuestions = allQuestions.filter(q => {
-            const difficultyMatch = q.difficulty === difficulty;
-            // Si onlyOptionQuestions es true, excluir preguntas con Correct === -1
-            const typeMatch = !onlyOptionQuestions || Number(q.correct) !== -1;
-            // Verificar si hay opciones repetidas cuando Correct no es -1
-            //const hasRepeatedOptions = (q.correct !== -1) &&
-            //    (q.option1 === q.option2 || q.option1 === q.option3 || q.option2 === q.option3);
-            //para las escritas
-            //return q.correct === -1;
-            const jaContestada = respuestasIds.includes(q.id.toString())
-            return difficultyMatch && typeMatch && !jaContestada;  //&& !hasRepeatedOptions;
-        }).sort(() => 0.5 - Math.random());
-        console.log('Preguntas filtradas:', filteredQuestions.length, 'Preguntas respondidas:', respuestasIds.length)
-        setPreguntasQuedan(filteredQuestions.length)
-        setQuestions(filteredQuestions.slice(0, numQuestions ?? 3));
-        setStartTime(Date.now());
-        setUserAnswers(new Array(filteredQuestions.length).fill(null));
-    }, [numQuestions, difficulty, respuestas]);
 
-    useEffect(() => {
-        if (!showExplanation && !quizFinished && !reviewMode) {
-            const countdown = setInterval(() => {
-                setTimer((prevTimer) => {
-                    if (prevTimer === 1) {
-                        clearInterval(countdown);
-                        handleAnswer(null);
-                        return 30;
-                    }
-                    return prevTimer - 1;
-                });
-            }, 1000);
-            return () => clearInterval(countdown);
-        }
-    }, [showExplanation, quizFinished, reviewMode, currentQuestion, questions]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [showExplanation, quizFinished, reviewMode, currentQuestion, questionsForSession]);
+
     const getTextOption = (respNum: Number) => {
-        if (respNum === 0) {
-            return questions[currentQuestion].option1;
-        } else if (respNum === 1) {
-            return questions[currentQuestion].option2;
-        } else if (respNum === 2) {
-            return questions[currentQuestion].option3;
-        } else {
-            return "Invalid response number";
-        }
+        if (!questionsForSession[currentQuestion]) return "Opzione non disponibile";
+        if (respNum === 0) return questionsForSession[currentQuestion].option1;
+        if (respNum === 1) return questionsForSession[currentQuestion].option2;
+        if (respNum === 2) return questionsForSession[currentQuestion].option3;
+        return "Numero risposta non valido";
     };
+
     const handleAnswer = (resposta: string | number | null) => {
-        //const boAcierto = Number(questions[currentQuestion].correct) !== -1 ? index == Number(questions[currentQuestion].correct) : index === 1
+        if (!questionsForSession[currentQuestion]) return;
+
         let boAcierto = false;
         let textoRespondido = '';
-        if (Number(questions[currentQuestion].correct) === -1) {
+        const currentQ = questionsForSession[currentQuestion];
+
+        if (Number(currentQ.correct) === -1) { // Domanda a risposta aperta
             if (typeof resposta === 'string') {
-                boAcierto = (resposta?.toLowerCase() === questions[currentQuestion].option1.toLowerCase())
+                boAcierto = (resposta.toLowerCase() === currentQ.option1.toLowerCase());
                 textoRespondido = resposta;
             }
-        } else
-        {
-            boAcierto = (Number(resposta) == Number(questions[currentQuestion].correct)   )
-            textoRespondido = getTextOption(Number(resposta))
+        } else { // Domanda a scelta multipla
+            boAcierto = (Number(resposta) === Number(currentQ.correct));
+            textoRespondido = getTextOption(Number(resposta));
         }
-            const respuesta: Respuesta = {
-                idUsuario: usuario?.id??'sense',
-                tipoPregunta: 'MC',
-                idPregunta: questions[currentQuestion].id,
+
+        if (saveResults && usuario?.id) { // Salva la risposta solo se l'utente ha scelto di salvare
+            const respuestaObj: Respuesta = {
+                idUsuario: usuario.id,
+                tipoPregunta: 'MC', // Multiple Choice o Misto se include aperte
+                idPregunta: currentQ.id,
                 respuesta: textoRespondido,
                 correcta: boAcierto
             };
-            guardarRespuesta(respuesta);
-        respuestas.push(respuesta);
+            guardarRespuesta(respuestaObj);
+        }
+
         setSelectedAnswer(resposta);
         setShowExplanation(true);
-        setTimer(30);
+        setTimer(30); // Resetta il timer per la prossima domanda o per la revisione
+
         const newUserAnswers = [...userAnswers];
         newUserAnswers[currentQuestion] = resposta;
         setUserAnswers(newUserAnswers);
+
         if (boAcierto) {
             setScore(score + 1);
         }
     };
 
     const nextQuestion = () => {
-        if (currentQuestion < questions.length - 1) {
+        if (currentQuestion < questionsForSession.length - 1) {
             setCurrentQuestion(currentQuestion + 1);
             setShowExplanation(false);
             setSelectedAnswer(null);
+            setTimer(30); // Resetta il timer per la nuova domanda
         } else {
             setQuizFinished(true);
             setEndTime(Date.now());
-            saveResult();
+            // saveResult() sarà chiamato dall'useEffect che dipende da quizFinished
         }
     };
 
-    const saveResult = () => {
-        const result = {
-            name,
-            score,
-            totalQuestions: questions.length,
-            difficulty,
-            date: new Date().toLocaleString()
-        };
-        console.log('Risultato salvato:', result);
-    };
+    // useEffect per chiamare saveResult quando quizFinished diventa true
+    useEffect(() => {
+        if (quizFinished && saveResults) { // Salva solo se l'utente ha scelto di salvare
+             const saveSession = () => {
+                if (!usuario || !usuario.id) {
+                    console.warn("Salvataggio risultato sessione: ID utente non disponibile.");
+                    const localResult = { name, score, totalQuestions: questionsForSession.length, difficulty, date: new Date().toLocaleString(), timeTakenSeconds: startTime && endTime ? (endTime - startTime) / 1000 : undefined };
+                    console.log('Risultato sessione (locale, utente non definito):', localResult);
+                    return;
+                }
+
+                const gameSession: GameSessionResult = {
+                    userId: usuario.id,
+                    gameType: 'QuizItalianoGPT',
+                    timestamp: new Date(),
+                    difficulty: difficulty,
+                    score: score,
+                    totalPossibleScore: questionsForSession.length,
+                    itemsPlayed: questionsForSession.length,
+                    timeTakenSeconds: startTime && endTime ? Math.round((endTime - startTime) / 1000) : undefined,
+                    gameSpecificDetails: { onlyOptionQuestions: onlyOptionQuestions, includePreviouslyAnswered: includePreviouslyAnswered }
+                };
+                saveGameSessionResult(gameSession);
+                console.log('Risultato sessione inviato a Firebase:', gameSession);
+            };
+            saveSession();
+        } else if (quizFinished && !saveResults) {
+            console.log("Quiz terminato, risultati non salvati per scelta dell'utente.");
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [quizFinished, saveResults, difficulty, name, onlyOptionQuestions, includePreviouslyAnswered, score, questionsForSession, usuario, startTime, endTime]);
+
 
     const formatTime = (milliseconds: number) => {
         const seconds = Math.floor(milliseconds / 1000);
@@ -225,6 +269,11 @@ const QuizItaliano: React.FC<QuizParams> = ({
                     <Button onClick={startReview} className="w-full bg-blue-500 hover:bg-blue-700 mt-4">
                         Rivedi le risposte
                     </Button>
+                    {onExit && (
+                        <Button onClick={onExit} className="w-full bg-gray-500 hover:bg-gray-700 text-white mt-2">
+                            Torna al Menu Principale
+                        </Button>
+                    )}
                 </CardContent>
                 <CardActions>
                     <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700">
@@ -240,9 +289,14 @@ const QuizItaliano: React.FC<QuizParams> = ({
             <Card className="w-full max-w-md mx-auto bg-gradient-to-r from-blue-100 to-green-100">
                 <CardContent>
                     <p className="text-center text-blue-800">Non che domanda [{difficulty}]</p>
-                    <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700">
+                    <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700 mb-2">
                         Riprova con Nuove Domande
                     </Button>
+                    {onExit && (
+                        <Button onClick={onExit} className="w-full bg-gray-500 hover:bg-gray-700 text-white">
+                            Torna al Menu Principale
+                        </Button>
+                    )}
                 </CardContent>
             </Card>
         );
@@ -297,6 +351,11 @@ const QuizItaliano: React.FC<QuizParams> = ({
                             </Button>
                             
                     )
+                )}
+                {onExit && !reviewMode && (
+                     <Button onClick={onExit} variant="outlined" size="small" sx={{ mt: 1, mb: 1 }}>
+                        Torna al Menu
+                    </Button>
                 )}
             </CardActions>    
         </Card>

--- a/src/corrigeClaude.tsx
+++ b/src/corrigeClaude.tsx
@@ -10,8 +10,8 @@ import {
     Container,
     Paper
 } from '@mui/material';
-import { fetchCorrige } from './firebase/firebaseFunctions';
-import { RegCorrige } from './firebase/firebaseInterfaces';
+import { fetchCorrige, saveGameSessionResult } from './firebase/firebaseFunctions'; // Aggiunto saveGameSessionResult
+import { RegCorrige, Usuario, GameSessionResult } from './firebase/firebaseInterfaces'; // Aggiunto Usuario, GameSessionResult
 import { keyframes } from '@emotion/react';
 
 const flipAnimation = keyframes`
@@ -38,9 +38,13 @@ interface Sentence {
 
 interface ItalianErrorDetectionGameProps {
     level: string;
+    onExit?: () => void;
+    usuario?: Usuario | null;
+    saveResults?: boolean;
+    includePreviouslyAnswered?: boolean; // Anche se meno diretta, la logica di quali frasi mostrare potrebbe esserne influenzata
 }
 
-const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ level }) => {
+const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ level, onExit, usuario, saveResults, includePreviouslyAnswered }) => {
     const [sentences, setSentences] = useState<Sentence[]>([]);
     const [currentSentenceIndex, setCurrentSentenceIndex] = useState(0);
     const [selectedWords, setSelectedWords] = useState<number[]>([]);
@@ -50,67 +54,136 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
     const [isGameOver, setIsGameOver] = useState(false);
     const [usedSentenceIds, setUsedSentenceIds] = useState<Set<string>>(new Set());
     const [flipWords, setFlipWords] = useState<number[]>([]);
+    const [sessionStartTime, setSessionStartTime] = useState<number | null>(null);
+    const [itemsPlayedInSession, setItemsPlayedInSession] = useState(0);
+    const [gameEndedByExit, setGameEndedByExit] = useState(false);
+    // const [initialSentenceLoaded, setInitialSentenceLoaded] = useState(false); // Non più necessario con la nuova logica di caricamento
+
+    // Tutte le frasi dal DB/CSV
+    const [allSentencesFromDB, setAllSentencesFromDB] = useState<Sentence[]>([]);
+    // ID delle frasi già risposte dall'utente
+    const [answeredSentenceIds, setAnsweredSentenceIds] = useState<Set<string>>(new Set());
+
+    // Conteggi per UI
+    // const [totalSentencesInDB, setTotalSentencesInDB] = useState(0); // allSentencesFromDB.length
+    const [possibleSentencesForCriteria, setPossibleSentencesForCriteria] = useState(0);
+    const [answeredForCriteriaCount, setAnsweredForCriteriaCount] = useState(0);
+    const [sentencesAvailableToPlay, setSentencesAvailableToPlay] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+    const [loading, setLoading] = useState(true);
+
 
     useEffect(() => {
-        const loadSentencesFromCSV = async (level: string): Promise<Sentence[]> => {
+        const loadDataAndSelectFirstSentence = async () => {
+            setLoading(true);
+            setError(null);
+            setSessionStartTime(Date.now());
+            setItemsPlayedInSession(0);
+            setGameEndedByExit(false);
+            setScore(0);
+            setTimeLeft(30);
+            setIsGameOver(false);
+            setFlipWords([]);
+            setSelectedWords([]);
+            setShowResult(false);
+
             try {
-                const corrige = await fetchCorrige();
-                return corrige
-                    .filter((q: RegCorrige) => q.nivel === level)
-                    .map(q => {
-                        const isSentenceNaturallyCorrect = !q.idsPalabrasErroneas || q.idsPalabrasErroneas.trim() === "";
-                        return {
-                            id: q.id,
-                            level: q.nivel,
-                            text: q.fraseCompleta,
-                            theme: q.tema,
-                            isNaturallyCorrect: isSentenceNaturallyCorrect,
-                            words: q.fraseCompleta.split(' ').map((word, index) => {
-                                const isError = !isSentenceNaturallyCorrect && q.idsPalabrasErroneas.split('|').map(Number).includes(index + 1);
-                                const errorIndex = !isSentenceNaturallyCorrect ? q.idsPalabrasErroneas.split('|').map(Number).indexOf(index + 1) : -1;
-                                return {
-                                    id: index + 1,
-                                    text: word,
-                                    isCorrect: isSentenceNaturallyCorrect ? true : !isError,
-                                    correction: isError && q.correcciones ? q.correcciones.split('|')[errorIndex] : null,
-                                    explanation: isError && q.explicacion ? q.explicacion.split('|')[errorIndex] : null
-                                };
-                            })
-                        };
-                    });
-            } catch (error) {
-                console.error('Errore nel caricamento delle frasi:', error);
-                return [];
+                // 1. Carica tutte le frasi se non già fatto
+                let currentAllSentences = allSentencesFromDB;
+                if (currentAllSentences.length === 0) {
+                    const corrigeItems = await fetchCorrige(); // Questa è RegCorrige[]
+                    currentAllSentences = corrigeItems.map(q => ({ // Trasforma in Sentence[]
+                        id: q.id,
+                        level: q.nivel,
+                        text: q.fraseCompleta,
+                        theme: q.tema,
+                        isNaturallyCorrect: !q.idsPalabrasErroneas || q.idsPalabrasErroneas.trim() === "",
+                        words: q.fraseCompleta.split(' ').map((word, index) => {
+                            const isError = !(!q.idsPalabrasErroneas || q.idsPalabrasErroneas.trim() === "") && q.idsPalabrasErroneas.split('|').map(Number).includes(index + 1);
+                            const errorIndex = !(!q.idsPalabrasErroneas || q.idsPalabrasErroneas.trim() === "") ? q.idsPalabrasErroneas.split('|').map(Number).indexOf(index + 1) : -1;
+                            return {
+                                id: index + 1,
+                                text: word,
+                                isCorrect: !isError,
+                                correction: isError && q.correcciones ? q.correcciones.split('|')[errorIndex] : null,
+                                explanation: isError && q.explicacion ? q.explicacion.split('|')[errorIndex] : null
+                            };
+                        })
+                    }));
+                    setAllSentencesFromDB(currentAllSentences);
+                }
+
+                // 2. Recupera ID delle frasi già risposte
+                let currentAnsweredIds = answeredSentenceIds;
+                if (usuario?.id && process.env.REACT_APP_USE_DATABASE === 'true') {
+                     // Controlla se ricaricare gli ID risposti o usare quelli in stato se disponibili e validi
+                     // Per semplicità, li ricarichiamo se l'utente cambia o la prop includePreviouslyAnswered cambia
+                    const answeredMap = await fetchAnsweredQuestionIdsGroupedByType(usuario.id);
+                    currentAnsweredIds = answeredMap['CO'] || new Set<string>(); // 'CO' per Corrige
+                    setAnsweredSentenceIds(currentAnsweredIds);
+                }
+
+                // 3. Filtra per livello
+                const sentencesForLevel = currentAllSentences.filter(s => s.level === level);
+                setPossibleSentencesForCriteria(sentencesForLevel.length);
+
+                // 4. Calcola quante di queste sono già state risposte
+                const answeredInLevel = sentencesForLevel.filter(s => currentAnsweredIds.has(s.id));
+                setAnsweredForCriteriaCount(answeredInLevel.length);
+
+                // 5. Determina il pool di frasi
+                let poolForSelection: Sentence[];
+                if (includePreviouslyAnswered) {
+                    poolForSelection = [...sentencesForLevel];
+                } else {
+                    poolForSelection = sentencesForLevel.filter(s => !currentAnsweredIds.has(s.id));
+                }
+                setSentencesAvailableToPlay(poolForSelection.length);
+
+                setUsedSentenceIds(new Set()); // Resetta le frasi usate per la nuova sessione
+
+                if (poolForSelection.length > 0) {
+                    const initialIdx = Math.floor(Math.random() * poolForSelection.length);
+                    setSentences(poolForSelection); // Imposta le frasi disponibili per la sessione (da cui pescare)
+                    setCurrentSentenceIndex(initialIdx); // Imposta l'indice per la prima frase
+                    setUsedSentenceIds(prev => new Set(prev).add(poolForSelection[initialIdx].id)); // Segna la prima come usata
+                } else {
+                    setSentences([]); // Nessuna frase disponibile
+                    setCurrentSentenceIndex(0); // o -1 per indicare nessuna frase
+                }
+
+            } catch (e) {
+                console.error('Errore nel caricamento dati per CorrigeClaude:', e);
+                setError('Errore caricamento frasi.');
+            } finally {
+                setLoading(false);
             }
         };
+        loadDataAndSelectFirstSentence();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [level, includePreviouslyAnswered, usuario?.id]); // Ricarica se livello o opzione di inclusione cambiano
 
-        const fetchSentences = async () => {
-            const loadedSentences = await loadSentencesFromCSV(level);
-            setSentences(loadedSentences);
-            console.log("Frasi caricate:", loadedSentences.length);
-        };
-
-        fetchSentences();
-    }, [level]);
-
-    const currentSentence = sentences[currentSentenceIndex];
+    const currentSentence = sentences[currentSentenceIndex]; // Questa ora si basa sulle frasi filtrate per la sessione
 
     useEffect(() => {
         let timer: NodeJS.Timeout;
         if (timeLeft > 0 && !isGameOver && currentSentence && !showResult && !currentSentence.isNaturallyCorrect) {
             timer = setTimeout(() => setTimeLeft(timeLeft - 1), 1000);
-        } else if (timeLeft === 0 && !isGameOver && !showResult && !currentSentence.isNaturallyCorrect) {
-            checkAnswer(); // Only call checkAnswer if it's not a naturally correct sentence
+        } else if (timeLeft === 0 && !isGameOver && !showResult && currentSentence && !currentSentence.isNaturallyCorrect) { // Aggiunto check currentSentence
+            checkAnswer();
         }
         return () => clearTimeout(timer);
-    }, [timeLeft, isGameOver, currentSentence, showResult]); // isCurrentSentenceNaturallyCorrect is implicitly handled by currentSentence check
+    }, [timeLeft, isGameOver, currentSentence, showResult]);
 
     // New useEffect to handle naturally correct sentences immediately
     useEffect(() => {
-        if (currentSentence && currentSentence.isNaturallyCorrect) {
+        if (currentSentence && currentSentence.isNaturallyCorrect && !showResult) { // Esegui solo se showResult è false
             setShowResult(true);
+            // Considera di incrementare itemsPlayedInSession anche per frasi naturalmente corrette
+            // se vuoi che contino nel totale delle frasi "viste" o "giocate".
+            // Per ora, itemsPlayedInSession viene incrementato in nextSentence.
         }
-    }, [currentSentence]);
+    }, [currentSentence, showResult]);
 
     useEffect(() => {
         if (showResult && currentSentence) {
@@ -172,16 +245,123 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
         }
     };
 
-    const restartGame = () => {
-        setCurrentSentenceIndex(0);
-        setSelectedWords([]);
-        setShowResult(false);
-        setScore(0);
-        setTimeLeft(30);
-        setIsGameOver(false);
-        setUsedSentenceIds(new Set());
-        setFlipWords([]);
+    const saveErrorDetectionSession = () => {
+        if (gameEndedByExit) return; // Non salvare se il gioco è già terminato con un salvataggio precedente all'uscita
+
+        if (!usuario || !usuario.id) {
+            console.warn("Salvataggio sessione Rilevamento Errori: ID utente non disponibile.");
+            return;
+        }
+        if (itemsPlayedInSession === 0 && !(currentSentence && currentSentence.isNaturallyCorrect && itemsPlayedInSession === 0) ) {
+             // Salva anche se itemsPlayedInSession è 0 ma la prima frase era naturalmente corretta
+            console.log("Salvataggio sessione Rilevamento Errori: Nessuna frase effettivamente giocata (oltre la prima se naturalmente corretta).");
+            return;
+        }
+
+        const timeTakenSeconds = sessionStartTime ? Math.round((Date.now() - sessionStartTime) / 1000) : undefined;
+        // Se l'ultima frase era naturalmente corretta e non è stata contata in itemsPlayedInSession tramite nextSentence
+        // potremmo volerla contare qui se `checkAnswer` non è stata chiamata per essa.
+        // Per ora, itemsPlayedInSession è incrementato solo in nextSentence.
+        const finalItemsPlayed = itemsPlayedInSession === 0 && currentSentence?.isNaturallyCorrect ? 1 : itemsPlayedInSession;
+
+
+        const gameSession: GameSessionResult = {
+            userId: usuario.id,
+            gameType: 'ErrorDetection',
+            timestamp: new Date(),
+            difficulty: level,
+            score: score, // Punteggio finale
+            itemsPlayed: finalItemsPlayed,
+            timeTakenSeconds: timeTakenSeconds,
+            gameSpecificDetails: {
+                theme: sentences.find(s => usedSentenceIds.has(s.id))?.theme || currentSentence?.theme || "Misto"
+            }
+        };
+        saveGameSessionResult(gameSession);
+        console.log("Risultato sessione Rilevamento Errori inviato a Firebase:", gameSession);
     };
+
+    const handleGameOver = () => {
+        if (!isGameOver) { // Evita doppie chiamate
+            saveErrorDetectionSession();
+            setIsGameOver(true);
+        }
+    };
+
+    const handleExitRequest = () => {
+        if (!isGameOver && !gameEndedByExit) { // Solo se il gioco non è già terminato per altre ragioni
+            setGameEndedByExit(true); // Imposta il flag
+            saveErrorDetectionSession(); // Salva lo stato attuale
+        }
+        if (onExit) {
+            onExit();
+        }
+    };
+
+    // useEffect per chiamare handleGameOver quando `isGameOver` diventa true da altre parti (es. nextSentence)
+    useEffect(() => {
+        if (isGameOver && !gameEndedByExit) { // Assicurati che non sia già stato gestito da un'uscita
+            handleGameOver();
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isGameOver, gameEndedByExit]); // Rimosso saveErrorDetectionSession dalle dipendenze per evitare loop
+
+
+    const nextSentence = () => {
+        if (currentSentence) { // Conta la frase corrente come giocata
+            setItemsPlayedInSession(prev => prev + 1);
+        }
+
+        const availableSentences = sentences.filter(s => !usedSentenceIds.has(s.id));
+
+        if (availableSentences.length > 0) {
+            const nextIndexInAvailable = Math.floor(Math.random() * availableSentences.length);
+            const nextSentenceId = availableSentences[nextIndexInAvailable].id;
+            const newCurrentSentenceIndex = sentences.findIndex(s => s.id === nextSentenceId);
+
+            if (newCurrentSentenceIndex !== -1) {
+                 setCurrentSentenceIndex(newCurrentSentenceIndex);
+                 setUsedSentenceIds(prev => new Set(prev).add(nextSentenceId));
+            } else {
+                 // Questo non dovrebbe accadere se availableSentences.length > 0
+                 console.error("Logica errore in nextSentence: frase non trovata");
+                 setIsGameOver(true); // Termina se c'è un errore imprevisto
+                 return;
+            }
+            setSelectedWords([]);
+            setShowResult(false);
+            setTimeLeft(30);
+            setFlipWords([]);
+        } else {
+            setIsGameOver(true);
+        }
+    };
+
+    const restartGame = () => {
+        // L'useEffect principale [level, includePreviouslyAnswered, usuario?.id]
+        // si occuperà di resettare la maggior parte degli stati e ricaricare i dati.
+        // Qui possiamo forzare un cambio di stato che triggera l'useEffect se necessario,
+        // o semplicemente resettare gli stati che non sono coperti.
+        // Per forzare il re-fetch completo e la riselezione, potremmo resettare allSentencesFromDB se volessimo
+        // ma è meglio affidarsi al cambio delle props o a un pulsante esplicito "cambia livello"
+        setLoading(true); // Mostra caricamento mentre l'useEffect fa il suo lavoro
+        // Cambiare una dipendenza dell'useEffect principale forzerà il suo rieseguimento.
+        // Ad esempio, potremmo avere uno stato `gameIteration` da incrementare.
+        // Per ora, l'useEffect si basa su level, includePreviouslyAnswered, usuario?.id.
+        // Se questi non cambiano, il reset completo non avviene.
+        // Per un vero "restart" che ricarica tutto come se fosse la prima volta:
+        setAllSentencesFromDB([]); // Forza il ricaricamento delle frasi da DB
+        setAnsweredSentenceIds(new Set()); // Forza il ricaricamento delle risposte
+        // L'useEffect [level, includePreviouslyAnswered, usuario?.id] verrà rieseguito.
+    };
+
+
+    if (loading) {
+        return <Container maxWidth="sm"><Box textAlign="center" mt={4}><Typography>Caricamento frasi...</Typography></Box></Container>;
+    }
+    if (error) {
+        return <Container maxWidth="sm"><Box textAlign="center" mt={4}><Typography color="error">{error}</Typography></Box></Container>;
+    }
 
     if (isGameOver) {
         return (
@@ -189,33 +369,75 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
                 <Box textAlign="center" mt={4}>
                     <Typography variant="h4" gutterBottom>Gioco terminato!</Typography>
                     <Typography variant="h6" gutterBottom>Punteggio finale: {score}</Typography>
-                    <Button variant="contained" color="primary" onClick={restartGame}>
-                        Gioca di nuovo
+                    <Typography variant="body2" gutterBottom>Frasi giocate in questa sessione: {itemsPlayedInSession}</Typography>
+                    <Button variant="contained" color="primary" onClick={restartGame} sx={{ mr: 1, mt:1 }}>
+                        Gioca di nuovo (Stesso Livello)
                     </Button>
+                    {onExit && ( // handleExitRequest si occuperà del salvataggio se necessario
+                        <Button variant="contained" color="secondary" onClick={handleExitRequest} sx={{mt:1}}>
+                            Torna al Menu Principale
+                        </Button>
+                    )}
                 </Box>
             </Container>
         );
     }
 
-    if (!currentSentence) {
-        return <Typography>Caricamento...</Typography>;
+    // Se non ci sono frasi disponibili DOPO il caricamento e i filtri
+    if (!currentSentence && !loading) {
+         return (
+            <Container maxWidth="md">
+                <Box my={4} textAlign="center">
+                    <Typography variant="h5" gutterBottom>Gioco di Rilevamento Errori</Typography>
+                    <Typography variant="h6" gutterBottom>Livello: {level}</Typography>
+                     <Box sx={{ fontSize: '0.85rem', color: 'text.secondary', mb: 2 }}>
+                        <Typography variant="body2">Frasi totali per livello {level}: {possibleSentencesForCriteria}</Typography>
+                        <Typography variant="body2">Già risposte: {answeredForCriteriaCount}</Typography>
+                        <Typography variant="body2" sx={{ fontWeight: 'bold' }}>Disponibili per giocare ora: {sentencesAvailableToPlay}</Typography>
+                    </Box>
+                    <Typography color="error" gutterBottom>
+                        {possibleSentencesForCriteria > 0 && sentencesAvailableToPlay === 0 && !includePreviouslyAnswered
+                            ? "Hai corretto tutte le frasi disponibili per questo livello!"
+                            : "Nessuna frase trovata per i criteri selezionati."
+                        }
+                    </Typography>
+                    <Typography>
+                        Prova a cambiare livello o includi le frasi già corrette tramite le opzioni nel menu principale.
+                    </Typography>
+                    {onExit && (
+                        <Button variant="contained" color="primary" onClick={handleExitRequest} style={{ marginTop: '20px' }}>
+                            Torna al Menu Principale
+                        </Button>
+                    )}
+                </Box>
+            </Container>
+        );
     }
+
+    // Se currentSentence è ancora undefined ma non stiamo più caricando (dovrebbe essere coperto sopra)
+    if (!currentSentence) {
+        return <Typography>Errore imprevisto: nessuna frase corrente.</Typography>;
+    }
+
 
     const isAnswerCorrect = currentSentence.words.every(word =>
         (word.isCorrect && !selectedWords.includes(word.id)) ||
         (!word.isCorrect && selectedWords.includes(word.id))
     );
 
-    const isCurrentSentenceNaturallyCorrect = currentSentence?.isNaturallyCorrect === true;
+    const isCurrentSentenceNaturallyCorrect = currentSentence.isNaturallyCorrect === true;
 
     return (
         <Container maxWidth="md">
             <Box my={4}>
-                <Typography variant="h4" gutterBottom>Gioco di Rilevamento Errori in Italiano</Typography>
-                <Typography variant="h6" gutterBottom>Livello: {level}</Typography>
-                <Box display="flex" justifyContent="space-between" mb={2}>
-                    <Typography gutterBottom>Id: {currentSentence?.id}</Typography>
-                    <Typography gutterBottom>Tema: {currentSentence?.theme}</Typography>
+                <Typography variant="h4" gutterBottom>Gioco di Rilevamento Errori</Typography>
+                 <Box sx={{ textAlign: 'center', fontSize: '0.75rem', color: 'text.secondary', mb: 1 }}>
+                    <Typography variant="caption" display="block">
+                        Livello: {level} | Tema: {currentSentence?.theme} | ID Frase: {currentSentence?.id}
+                    </Typography>
+                    <Typography variant="caption" display="block">
+                        Frasi possibili ({level}): {possibleSentencesForCriteria} | Già risposte: {answeredForCriteriaCount} | Disponibili: {sentencesAvailableToPlay}
+                    </Typography>
                 </Box>
                 <Box display="flex" justifyContent="space-between" mb={2}>
                     <Typography>Punteggio: {score}</Typography>
@@ -224,7 +446,7 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
                 <LinearProgress variant="determinate" value={(timeLeft / 30) * 100} />
                 <Paper elevation={3} style={{ padding: '20px', marginTop: '20px' }}>
                     <Box mb={2}>
-                        {currentSentence?.words.map(word => (
+                        {currentSentence.words.map(word => (
                             <Chip
                                 key={word.id}
                                 label={flipWords.includes(word.id) && !isCurrentSentenceNaturallyCorrect ? word.correction : word.text}
@@ -236,11 +458,11 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
                                     backgroundColor: showResult && !isCurrentSentenceNaturallyCorrect
                                         ? word.isCorrect
                                             ? selectedWords.includes(word.id)
-                                                ? '#ff6b6b' // rosso più intenso per le parole corrette erroneamente selezionate
+                                                ? '#ff6b6b'
                                                 : undefined
                                             : selectedWords.includes(word.id)
-                                                ? '#66bb6a' // verde per gli errori correttamente identificati
-                                                : '#ffcccb' // rosso chiaro per gli errori non identificati
+                                                ? '#66bb6a'
+                                                : '#ffcccb'
                                         : undefined,                                    
                                     animation: flipWords.includes(word.id) && !isCurrentSentenceNaturallyCorrect ? `${flipAnimation} 2s infinite` : 'none'
                                 }}
@@ -249,16 +471,16 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
                     </Box>
                 </Paper>
                 {isCurrentSentenceNaturallyCorrect && !showResult && (
-                    <Alert severity="info" style={{ marginTop: '20px' }}>Questa frase è già corretta!</Alert>
+                    <Alert severity="info" style={{ marginTop: '20px' }}>Questa frase è già corretta! Premi "Prossima frase" per continuare.</Alert>
                 )}
                 {!showResult && !isCurrentSentenceNaturallyCorrect && (
                     <Button variant="contained" color="primary" onClick={checkAnswer} style={{ marginTop: '20px' }}>
                         Verifica risposta
                     </Button>
                 )}
-                 {(showResult || isCurrentSentenceNaturallyCorrect) && (
+                 {(showResult || isCurrentSentenceNaturallyCorrect) && ( // Mostra sempre i pulsanti dopo che il risultato è mostrato o se la frase è naturalmente corretta
                     <Box mt={2}>
-                        {!isCurrentSentenceNaturallyCorrect && (
+                        {!isCurrentSentenceNaturallyCorrect && showResult && ( // Mostra solo se non naturalmente corretta E il risultato è mostrato
                             <Alert severity={isAnswerCorrect ? "success" : "error"}>
                                 <AlertTitle>
                                     {isAnswerCorrect
@@ -267,16 +489,26 @@ const ItalianErrorDetectionGame: React.FC<ItalianErrorDetectionGameProps> = ({ l
                                 </AlertTitle>
                             </Alert>
                         )}
-                        {!isCurrentSentenceNaturallyCorrect && currentSentence?.words.filter(word => !word.isCorrect).map(word => (
+                        {!isCurrentSentenceNaturallyCorrect && showResult && currentSentence.words.filter(word => !word.isCorrect).map(word => (
                             <Alert key={word.id} severity={selectedWords.includes(word.id) ? "success":"error" } style={{ marginTop: '10px' }}>
                                 <AlertTitle>Spiegazione per "{word.text}"</AlertTitle>
                                 {word.explanation}
                             </Alert>
                         ))}
-                        <Button variant="contained" color="primary" onClick={nextSentence} style={{ marginTop: '20px' }}>
+                        <Button variant="contained" color="primary" onClick={nextSentence} style={{ marginTop: '20px', marginRight: '10px' }}>
                             Prossima frase
                         </Button>
+                        {onExit && ( // Modificato per usare handleExitRequest
+                            <Button variant="contained" color="secondary" onClick={handleExitRequest} style={{ marginTop: '20px' }}>
+                                Torna al Menu Principale
+                            </Button>
+                        )}
                     </Box>
+                )}
+                 {!showResult && onExit && (
+                    <Button variant="outlined" color="secondary" onClick={handleExitRequest} style={{ marginTop: '20px', display: 'block' }}>
+                        Esci dal Gioco
+                    </Button>
                 )}
             </Box>
         </Container>

--- a/src/firebase/firebaseFunctions.tsx
+++ b/src/firebase/firebaseFunctions.tsx
@@ -1,7 +1,7 @@
 // firebaseFunctions.ts
 import { collection, query, where, getDocs, addDoc, updateDoc, doc, serverTimestamp, Timestamp, setDoc, DocumentData, WhereFilterOp, Query, arrayUnion } from 'firebase/firestore';
 import { db } from './firebase';
-import { Usuario, Respuesta, RegCorrige } from './firebaseInterfaces';
+import { Usuario, Respuesta, RegCorrige, GameSessionResult } from './firebaseInterfaces';
 import Papa from 'papaparse'; // Necesitarás instalar papaparse: npm install papaparse
 import { Paragraph, ParagraphQuestion, Question, RegImpiccato, RegQuote, RegTyping } from '../MyTypes';
 import { questionsCSV } from '../questionGPT4o';
@@ -275,6 +275,37 @@ export const fetchRespuestas = async (idUsuario: string): Promise<Respuesta[]> =
     console.log("respuestas leidas: " + respuestasData.length);
     return respuestasData;
 };
+
+export const fetchAnsweredQuestionIdsGroupedByType = async (userId: string): Promise<Record<string, Set<string>>> => {
+    if (process.env.REACT_APP_USE_DATABASE === 'false') {
+        console.log("Modalità offline: impossibile recuperare ID domande risposte.");
+        return {};
+    }
+
+    const answeredQuestionsMap: Record<string, Set<string>> = {};
+    try {
+        const respuestasRef = collection(db, 'respuestas');
+        const q = query(respuestasRef, where('idUsuario', '==', userId));
+        const querySnapshot = await getDocs(q);
+
+        querySnapshot.forEach(doc => {
+            const respuesta = doc.data() as Respuesta;
+            // Assicurati che tipoPregunta e idPregunta esistano e non siano stringhe vuote
+            if (respuesta.tipoPregunta && typeof respuesta.tipoPregunta === 'string' && respuesta.tipoPregunta.trim() !== "" &&
+                respuesta.idPregunta && typeof respuesta.idPregunta === 'string' && respuesta.idPregunta.trim() !== "") {
+                if (!answeredQuestionsMap[respuesta.tipoPregunta]) {
+                    answeredQuestionsMap[respuesta.tipoPregunta] = new Set<string>();
+                }
+                answeredQuestionsMap[respuesta.tipoPregunta].add(respuesta.idPregunta);
+            }
+        });
+        console.log(`Recuperati ID domande risposte raggruppati per tipo per utente ${userId}:`, answeredQuestionsMap);
+    } catch (error) {
+        console.error("Errore durante il recupero degli ID delle domande risposte: ", error);
+    }
+    return answeredQuestionsMap;
+};
+
 // Función para limpiar las claves del objeto
 function cleanObjectKeys(obj: Record<string, any>): Record<string, any> {
     return Object.keys(obj).reduce((acc, key) => {
@@ -404,3 +435,22 @@ export function parseCadenaCSV<T>(csv: string): T[] {
         }, {} as T);
     });
 }
+
+export const saveGameSessionResult = async (result: GameSessionResult): Promise<void> => {
+    if (process.env.REACT_APP_USE_DATABASE === 'false') {
+        console.log("Modalità offline: Risultato sessione di gioco non salvato in Firestore.", result);
+        return;
+    }
+    try {
+        const resultWithTimestamp = {
+            ...result,
+            timestamp: serverTimestamp() // Assicura che il timestamp sia quello del server
+        };
+        await addDoc(collection(db, "gameSessionResults"), resultWithTimestamp);
+        console.log("Risultato sessione di gioco salvato:", resultWithTimestamp);
+    } catch (e) {
+        console.error("Errore durante il salvataggio del risultato della sessione di gioco: ", e);
+        // Considera se rilanciare l'errore o gestirlo in modo specifico
+        // throw e;
+    }
+};

--- a/src/firebase/firebaseInterfaces.tsx
+++ b/src/firebase/firebaseInterfaces.tsx
@@ -33,4 +33,27 @@ export interface RegCorrige {
     explicacion: string;//Array separadas por |
     tema: string;
 } 
+
+export interface GameSessionResult {
+  userId: string; // ID dell'utente da Firebase Auth o l'ID dell'oggetto Usuario
+  gameType: string; // Es. 'QuizItalianoGPT', 'Impiccato', 'TypingTutor', 'ErrorDetection', 'ParagraphCompletion'
+  timestamp: any; // Per Firestore serverTimestamp()
+  difficulty?: string; // Livello di difficoltà se applicabile (A1, B2, ecc.)
+  score?: number; // Punteggio ottenuto
+  totalPossibleScore?: number; // Punteggio massimo possibile o numero totale di item
+  timeTakenSeconds?: number; // Tempo impiegato in secondi
+  itemsPlayed?: number; // Numero di domande, parole, frasi giocate
+  gameSpecificDetails?: { // Oggetto per dettagli specifici del gioco
+    [key: string]: any; // Permette qualsiasi altro dato specifico
+    wpm?: number; // Velocità media parole al minuto (per TypingTutor)
+    accuracy?: number; // Precisione media (per TypingTutor)
+    realAccuracy?: number; // Precisione reale media (per TypingTutor)
+    theme?: string; // Tema o categoria (per TypingTutor, ErrorDetection)
+    errorsCorrected?: number; // Numero di errori corretti (per ErrorDetection)
+    errorsMissed?: number; // Numero di errori non identificati (per ErrorDetection)
+    falsePositives?: number; // Numero di parole corrette selezionate erroneamente (per ErrorDetection)
+    // Aggiungere altri campi specifici se necessario per altri giochi
+  };
+}
+
 export default Usuario;

--- a/src/impiccato.tsx
+++ b/src/impiccato.tsx
@@ -1,125 +1,139 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { Select, MenuItem, Card, CardContent, Typography, Alert, Chip, SelectChangeEvent, Box, Button } from '@mui/material';
 import { QuizParams, RegImpiccato} from './MyTypes';
-import { fetchImpiccato, fetchRespuestas, guardarRespuesta } from './firebase/firebaseFunctions';
+import { fetchImpiccato, guardarRespuesta, fetchAnsweredQuestionIdsGroupedByType } from './firebase/firebaseFunctions'; // fetchRespuestas rimosso
 import GlobalKeyCaptureTextField from './components/global-key-capture-text-field';
-import { Respuesta } from './firebase/firebaseInterfaces';
+import { Respuesta } from './firebase/firebaseInterfaces'; // Non più usata per caricare tutte le risposte qui
 //import { impiccatoCSV } from './question.Impiccato';
-type Difficulty = 'facile' | 'medio' | 'difficile';
+
+type DifficultyInternal = 'facile' | 'medio' | 'difficile'; // Rinomina per evitare collisioni se Difficulty è globale
+type WordLevel = 'A2' | 'B1' | 'B2'; // Tipo per il livello delle parole
 
 const Imppicato: React.FC<QuizParams> = ({
-    usuario = null
+    usuario = null,
+    onExit,
+    difficulty: initialDifficulty = 'B1', // Default a B1 se non fornito, o usa quello da AppIniziale
+    saveResults = true,
+    includePreviouslyAnswered = false
 }) => {
-    const [words, setWords] = useState<RegImpiccato[]>([]);
+    const [allWordsFromDB, setAllWordsFromDB] = useState<RegImpiccato[]>([]); // Tutte le parole caricate
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
     const [currentWord, setCurrentWord] = useState<RegImpiccato | null>(null);
     const [guessedLetters, setGuessedLetters] = useState<string[]>([]);
     const [remainingAttempts, setRemainingAttempts] = useState<number>(0);
-    //const [input, setInput] = useState<string>('');
-    const [difficulty, setDifficulty] = useState<Difficulty>('medio');
-    const [level, setLevel] = useState<RegImpiccato['level']>('A2');
+
+    const [gameDifficulty, setGameDifficulty] = useState<DifficultyInternal>('medio'); // Stato per la difficoltà del gioco attuale
+    const [wordLevel, setWordLevel] = useState<WordLevel>(initialDifficulty as WordLevel); // Livello delle parole (A2,B1,B2) basato sulla prop difficulty
+
     const [message, setMessage] = useState<string>('');
     const [timer, setTimer] = useState<number>(30);
     const [gameOver, setGameOver] = useState<boolean>(false);
     const [showTip, setShowTip] = useState<boolean>(false);
-    //const [consecutiveFailures, setConsecutiveFailures] = useState<number>(0);
     const [category, setCategory] = useState<string>('Tutte');
     const [showCategory, setShowCategory] = useState<boolean>(false);
-    const [respuestas, setRespuestas] = useState<Respuesta[]>([]);
-    useEffect(() => {
-        const loadRespuestas = async () => {
-            try {
-                const respuestasData = await fetchRespuestas(usuario?.id ?? 'sense');
-                setRespuestas(respuestasData);
-            } catch (error) {
-                console.error('Errore nel recupero delle parole:', error);
-            }
-        };
-        loadRespuestas();
-    }, [usuario]);
+    // const [respuestas, setRespuestas] = useState<Respuesta[]>([]); // Sostituito da answeredWordIds
+
+    // Stati per i conteggi
+    const [totalWordsInDB, setTotalWordsInDB] = useState(0);
+    const [possibleWordsForCriteria, setPossibleWordsForCriteria] = useState(0);
+    const [answeredWordsForCriteriaCount, setAnsweredWordsForCriteriaCount] = useState(0);
+    const [wordsAvailableToPlay, setWordsAvailableToPlay] = useState(0);
+    const [answeredWordIds, setAnsweredWordIds] = useState<Set<string>>(new Set());
 
     useEffect(() => {
-        const loadWords = async () => {
-            
+        const loadInitialData = async () => {
+            setLoading(true);
+            setError(null);
             try {
-                setLoading(true);
-                const fetchedWords = await fetchImpiccato();
-                setWords(fetchedWords);
-                setError(null);
-            } catch (err) {                
-                setError('Words desde file');
-                console.error('Error fetching words:', err);
+                // Carica tutte le parole se non già fatto
+                if (allWordsFromDB.length === 0) {
+                    const fetchedWords = await fetchImpiccato();
+                    setAllWordsFromDB(fetchedWords);
+                    setTotalWordsInDB(fetchedWords.length);
+                }
+
+                // Carica ID delle parole già risposte
+                if (usuario?.id && process.env.REACT_APP_USE_DATABASE === 'true') {
+                    const answeredMap = await fetchAnsweredQuestionIdsGroupedByType(usuario.id);
+                    setAnsweredWordIds(answeredMap['AH'] || new Set<string>()); // 'AH' per Ahorcado/Impiccato
+                }
+            } catch (err) {
+                setError('Errore nel caricamento dati iniziali. Riprova.');
+                console.error('Error fetching initial data for Hangman:', err);
             } finally {
                 setLoading(false);
             }
         };
+        loadInitialData();
+    }, [usuario?.id, allWordsFromDB.length]); // Dipende da utente e se allWordsFromDB è già popolato
 
-        loadWords();
-    }, []);
-    //cambio al pasar a FireStone lectura asyncrona
     const selectNewWord = useCallback(() => {
-        const filteredWords = words.filter(word => {
-            const levelMatch = word.level === level;
+        if (allWordsFromDB.length === 0) {
+            setError('Nessuna parola caricata dalla base dati.');
+            return;
+        }
+
+        // 1. Filtra per livello (wordLevel) e categoria
+        const wordsMatchingCriteria = allWordsFromDB.filter(word => {
+            const levelMatch = word.level === wordLevel;
             const categoryMatch = category === 'Tutte' || word.category === category;
-            //console.log('Palabra:', word.word, 'Nivel:', word.level, 'Categoría:', word.category, 'Match:', levelMatch && categoryMatch); // Depuración
             return levelMatch && categoryMatch;
         });
-        if (filteredWords.length === 0) {
-            setError('Non ci sono parole disponibili per la combinazione di livello e categoria selezionata.');
+        setPossibleWordsForCriteria(wordsMatchingCriteria.length);
+
+        // 2. Calcola quante di queste sono già state risposte
+        const answeredInCriteria = wordsMatchingCriteria.filter(p => answeredWordIds.has(p.word.toLowerCase())); // Assumendo che idPregunta sia la parola stessa
+        setAnsweredWordsForCriteriaCount(answeredInCriteria.length);
+
+        // 3. Determina il pool di parole da cui scegliere
+        let poolForWordSelection: RegImpiccato[];
+        if (includePreviouslyAnswered) {
+            poolForWordSelection = [...wordsMatchingCriteria];
+        } else {
+            poolForWordSelection = wordsMatchingCriteria.filter(p => !answeredWordIds.has(p.word.toLowerCase()));
+        }
+        setWordsAvailableToPlay(poolForWordSelection.length);
+
+        if (poolForWordSelection.length === 0) {
+            setError('Nessuna parola disponibile per i criteri selezionati. Prova a cambiare livello, categoria o includi parole già giocate.');
+            setCurrentWord(null); // Assicura che non ci sia una parola corrente
             return;
-        };
-        let availableWords;
-        if (respuestas.length > 0) {
-            // Filtra i paragrafi non ancora risposti
-            const respuestasWords = respuestas.map(r => r.idPregunta);
-            availableWords = filteredWords.filter(p => !respuestasWords.includes(p.word));
-            if (availableWords.length === 0) {
-                setError('Non ci sono parole disponibili per la combinazione di livello e categoria selezionata. Non utilizati');
-                return;
-            };
-        } else availableWords=[...filteredWords];
-        if (availableWords.length === 0) {
-            setError('Non ci sono parole disponibili per la combinazione di livello e categoria selezionata.');
-            return;
-        };
-        const randomWord = availableWords[Math.floor(Math.random() * availableWords.length)];
-        //console.log('Palabra seleccionada:', randomWord.word);
-        //Lo paso a minusculas por si aca
-        setCurrentWord({
-            ...randomWord,
-            word: randomWord.word.toLowerCase()
-        });
+        }
+        setError(null); // Pulisce errori precedenti se ora ci sono parole
+
+        const randomWord = poolForWordSelection[Math.floor(Math.random() * poolForWordSelection.length)];
+        setCurrentWord({ ...randomWord, word: randomWord.word.toLowerCase() });
         setRemainingAttempts(6);
-        setMessage(`Ci sono ${availableWords.length} di questo tipo ancora `);
+        setMessage(`Parole disponibili per questi filtri: ${poolForWordSelection.length}`);
         setTimer(30);
         setGameOver(false);
         setShowTip(false);
-        setShowCategory(false);        
+        setShowCategory(false);
         setGuessedLetters([]);
+
         let initialLetters: string[] = [];
-        if (difficulty !== 'difficile') {
-            const initialLettersCount = {
-                facile: Math.floor(randomWord.word.length / 3),
-                medio: Math.floor(randomWord.word.length / 4),
-            }[difficulty];
-
+        if (gameDifficulty !== 'difficile') {
+            const initialCountFactor = gameDifficulty === 'facile' ? 3 : 4;
+            const initialLettersCount = Math.floor(randomWord.word.length / initialCountFactor);
             const uniqueLetters = [...new Set(randomWord.word.split(''))];
-            const shuffled = uniqueLetters.sort(() => 0.5 - Math.random());
-            initialLetters = shuffled.slice(0, initialLettersCount);
+            initialLetters = uniqueLetters.sort(() => 0.5 - Math.random()).slice(0, initialLettersCount);
         }
+        setGuessedLetters(randomWord.word.split('').filter(letter => initialLetters.includes(letter)));
 
-        const allInitialLetters = randomWord.word.split('').filter(letter => initialLetters.includes(letter));
-        setGuessedLetters(allInitialLetters);
-    }, [words, level, category, difficulty, respuestas]);
+    }, [allWordsFromDB, wordLevel, category, includePreviouslyAnswered, answeredWordIds, gameDifficulty]);
 
+    // Effetto per selezionare una nuova parola quando cambiano i filtri o allWordsFromDB/answeredWordIds
     useEffect(() => {
-        if (!loading && words.length > 0) {
+        if (!loading && allWordsFromDB.length > 0) { // Assicurati che i dati base siano caricati
             selectNewWord();
         }
-    }, [loading, words, difficulty, level, category, selectNewWord]);
+    }, [loading, allWordsFromDB, selectNewWord]); // Rimosso gameDifficulty, wordLevel, category, includePreviouslyAnswered, answeredWordIds perché sono già dipendenze di selectNewWord
+                                                 // e selectNewWord è in useCallback, quindi non cambia a meno che le sue dipendenze non cambino.
+                                                 // Questo evita chiamate multiple non necessarie.
+                                                 // Mantenere selectNewWord qui assicura che venga chiamata dopo il caricamento iniziale.
 
-    const handleTimeUp =  useCallback((): void => {
+    const handleTimeUp = useCallback((): void => {
         if (currentWord) {
             setMessage(`Tempo scaduto! La parola era "${currentWord.word}".`);
             endGame('Tempo scaduto');
@@ -151,19 +165,25 @@ const Imppicato: React.FC<QuizParams> = ({
     }
     const logGameResult = (reason: string): void => {
         if (currentWord) {
-            const isCorrect = 'Parola indovinata' === reason;  //currentWord.word === guessedLetters.join('');
-            console.log(`Parola originale: ${currentWord.word} Indovinata: ${isCorrect ? 'Sì' : 'No'}
-        Livello: ${currentWord.level} Difficoltà: ${difficulty} Motivo fine gioco: ${reason}`);
-            const respuesta: Respuesta = {
-                idUsuario: usuario?.id ?? 'sense',
-                tipoPregunta: 'AH',
-                idPregunta: currentWord.word,
-                idSubPregunta: "0",
-                respuesta: reason,
-                correcta: isCorrect
-            };
-            guardarRespuesta(respuesta)
-            respuestas.push(respuesta);
+            const isCorrect = 'Parola indovinata' === reason;
+            console.log(`Parola originale: ${currentWord.word} Indovinata: ${isCorrect ? 'Sì' : 'No'} Livello: ${currentWord.level} Difficoltà interna: ${gameDifficulty} Motivo fine gioco: ${reason}`);
+
+            if (saveResults && usuario?.id) { // Condiziona il salvataggio
+                const respuesta: Respuesta = {
+                    idUsuario: usuario.id,
+                    tipoPregunta: 'AH', // Ahorcado (Impiccato)
+                    idPregunta: currentWord.word, // La parola stessa è l'ID
+                    idSubPregunta: "0", // Non applicabile o standard a 0
+                    respuesta: reason, // Es. 'Parola indovinata', 'Tentativi esauriti', 'Tempo scaduto'
+                    correcta: isCorrect
+                };
+                guardarRespuesta(respuesta);
+                // Aggiorna localmente il set di ID risposti per riflettere immediatamente la parola giocata
+                // senza dover fare un altro fetch, se l'utente continua a giocare nella stessa sessione.
+                setAnsweredWordIds(prev => new Set(prev).add(currentWord.word.toLowerCase()));
+            } else {
+                console.log("Salvataggio risposta saltato per scelta dell'utente o utente non loggato.");
+            }
         }
     }
 
@@ -234,6 +254,14 @@ const Imppicato: React.FC<QuizParams> = ({
                 <Typography variant="h5" component="div" gutterBottom>
                     Gioco dell'Impiccato
                 </Typography>
+                <Box sx={{ textAlign: 'center', fontSize: '0.75rem', color: 'text.secondary', mb: 1 }}>
+                    <Typography variant="caption" display="block">
+                        Livello Parole: {wordLevel} | Categoria: {category}
+                    </Typography>
+                    <Typography variant="caption" display="block">
+                        Parole possibili: {possibleWordsForCriteria} | Già risposte: {answeredWordsForCriteriaCount} | Disponibili: {wordsAvailableToPlay}
+                    </Typography>
+                </Box>
                 <Box sx={{
                     display: 'flex',
                     flexDirection: { xs: 'column', sm: 'row' },
@@ -243,22 +271,22 @@ const Imppicato: React.FC<QuizParams> = ({
                     marginBottom: 2
                 }}>
                     <Select
-                        value={difficulty}
-                        onChange={(e: SelectChangeEvent<Difficulty>) => setDifficulty(e.target.value as Difficulty)}
+                        value={gameDifficulty} // Usa lo stato interno per la difficoltà del gioco
+                        onChange={(e: SelectChangeEvent<DifficultyInternal>) => setGameDifficulty(e.target.value as DifficultyInternal)}
                         sx={{ minWidth: 120 }}
                     >
-                        <MenuItem value="facile">Facile</MenuItem>
-                        <MenuItem value="medio">Medio</MenuItem>
-                        <MenuItem value="difficile">Difficile</MenuItem>
+                        <MenuItem value="facile">Facile (Gioco)</MenuItem>
+                        <MenuItem value="medio">Medio (Gioco)</MenuItem>
+                        <MenuItem value="difficile">Difficile (Gioco)</MenuItem>
                     </Select>
                     <Select
-                        value={level}
-                        onChange={(e: SelectChangeEvent<RegImpiccato['level']>) => setLevel(e.target.value as RegImpiccato['level'])}
+                        value={wordLevel} // Usa lo stato per il livello delle parole
+                        onChange={(e: SelectChangeEvent<WordLevel>) => setWordLevel(e.target.value as WordLevel)}
                         sx={{ minWidth: 120 }}
                     >
-                        <MenuItem value="A2">A2</MenuItem>
-                        <MenuItem value="B1">B1</MenuItem>
-                        <MenuItem value="B2">B2</MenuItem>
+                        <MenuItem value="A2">Parole A2</MenuItem>
+                        <MenuItem value="B1">Parole B1</MenuItem>
+                        <MenuItem value="B2">Parole B2</MenuItem>
                     </Select>
                     <Typography
                         variant="h6"
@@ -319,9 +347,17 @@ const Imppicato: React.FC<QuizParams> = ({
                     </div>
                 )}
                 {currentWord && (
-                    <div><Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700">
-                        Fine del giocco
-                    </Button></div>
+                    <div style={{ marginTop: '16px' }}>
+                        {onExit ? (
+                            <Button onClick={onExit} variant="contained" color="secondary" fullWidth>
+                                Torna al Menu Principale
+                            </Button>
+                        ) : (
+                            <Button onClick={() => window.location.reload()} variant="contained" color="error" fullWidth>
+                                Esci (Ricarica)
+                            </Button>
+                        )}
+                    </div>
                 )}
             </CardContent>
         </Card>

--- a/src/parrafoClaude2.tsx
+++ b/src/parrafoClaude2.tsx
@@ -18,19 +18,23 @@ import Checkbox from '@mui/material/Checkbox';
 import { Paragraph, ParagraphQuestion, QuizParams } from './MyTypes.js';
 //import { paragraphsCSV, paragraphsQuestionsCSV } from './questionParrafo.js';
 import ResponsiveCard from './components/ResponsiveCard';
-import { Respuesta } from "./firebase/firebaseInterfaces";
-import { guardarRespuesta, fetchRespuestas, fetchParrafo, fetchParrafoSub } from './firebase/firebaseFunctions';
+import { Respuesta, GameSessionResult } from "./firebase/firebaseInterfaces";
+import { guardarRespuesta, fetchParrafo, fetchParrafoSub, saveGameSessionResult, fetchAnsweredQuestionIdsGroupedByType } from './firebase/firebaseFunctions';
 import QuestionComponent from './components/ParagraphQuestion';
+import { Typography, Box } from '@mui/material'; // Aggiunto per UI conteggi
 
 const ItalianLearningApp: React.FC<QuizParams> = ({
     numQuestions = 3,
     name = 'anonymous',
     onlyOptionQuestions = false,
     difficulty = 'B1',
-    usuario = null
+    usuario = null,
+    onExit,
+    saveResults = true, // Valore di default
+    includePreviouslyAnswered = false // Valore di default
 }) => {
     
-    const [respuestas, setRespuestas] = useState<Respuesta[]>([]);
+    // const [respuestas, setRespuestas] = useState<Respuesta[]>([]); // Non più usato direttamente per il fetch iniziale
     const [todosParagraphs, setTodosParagraphs] = useState<Paragraph[]>([]);
     const [todosQuestions, setTodosQuestions] = useState<ParagraphQuestion[]>([]);
 
@@ -49,76 +53,97 @@ const ItalianLearningApp: React.FC<QuizParams> = ({
     const [timer, setTimer] = useState(60);
     const [quizFinished, setQuizFinished] = useState(false);
     const [reviewMode, setReviewMode] = useState(false);
-    const [preguntasQuedan, setPreguntasQuedan] = useState(0);
+    // const [preguntasQuedan, setPreguntasQuedan] = useState(0); // Sostituito da paragraphsAvailableToPlay
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
-    
-    useEffect(() => {      
-        const loadRespuestas = async () => {
-            try {
-                const respuestasData = await fetchRespuestas(usuario?.id??'sense');
-                setRespuestas(respuestasData);
-            } catch (error) {
-                console.error('Errore nel recupero delle parole:', error);
-            }
-        };
-        loadRespuestas();
-    }, [usuario]);
 
-    // Carica paragrafi e domande
+    // Stati per i conteggi dei paragrafi
+    const [totalParagraphsInDB, setTotalParagraphsInDB] = useState(0);
+    const [possibleParagraphsForCriteria, setPossibleParagraphsForCriteria] = useState(0); // Paragrafi che matchano difficoltà (se applicabile)
+    const [answeredParagraphsForCriteriaCount, setAnsweredParagraphsForCriteriaCount] = useState(0);
+    const [paragraphsAvailableToPlay, setParagraphsAvailableToPlay] = useState(0);
+
     useEffect(() => {
-        const loadData = async () => {
+        const loadAndFilterData = async () => {
             setLoading(true);
+            setError(null);
             try {
-                const [fetchedParagraphs, fetchedQuestions] = await Promise.all([
-                    fetchParrafo(),
-                    fetchParrafoSub()
-                ]);
-                setTodosParagraphs(fetchedParagraphs);
-                setTodosQuestions(fetchedQuestions);
-                setError(null);
+                // 1. Carica tutti i paragrafi e le loro domande (una sola volta se non già caricati)
+                let currentTodosParagraphs = todosParagraphs;
+                let currentTodosQuestions = todosQuestions;
+
+                if (currentTodosParagraphs.length === 0) {
+                    currentTodosParagraphs = await fetchParrafo();
+                    setTodosParagraphs(currentTodosParagraphs);
+                    setTotalParagraphsInDB(currentTodosParagraphs.length);
+                }
+                if (currentTodosQuestions.length === 0) {
+                    currentTodosQuestions = await fetchParrafoSub();
+                    setTodosQuestions(currentTodosQuestions);
+                }
+
+                // 2. Recupera ID dei paragrafi già risposti dall'utente
+                let answeredParagraphIds = new Set<string>();
+                if (usuario?.id && process.env.REACT_APP_USE_DATABASE === 'true') {
+                    const answeredMap = await fetchAnsweredQuestionIdsGroupedByType(usuario.id);
+                    answeredParagraphIds = answeredMap['PR'] || new Set<string>(); // 'PR' per Paragrafo
+                }
+
+                // 3. Filtra paragrafi per difficoltà (se applicabile - attualmente i paragrafi non hanno difficoltà)
+                // Per ora, tutti i paragrafi caricati sono considerati "possibili"
+                const paragraphsMatchingCriteria = [...currentTodosParagraphs]; // Copia per evitare modifiche all'originale
+                setPossibleParagraphsForCriteria(paragraphsMatchingCriteria.length);
+
+                // 4. Calcola quanti di questi sono già stati risposti
+                const answeredAmongCriteria = paragraphsMatchingCriteria.filter(p => answeredParagraphIds.has(p.id.toString()));
+                setAnsweredParagraphsForCriteriaCount(answeredAmongCriteria.length);
+
+                // 5. Determina il pool di paragrafi da cui scegliere
+                let poolOfParagraphs: Paragraph[];
+                if (includePreviouslyAnswered) {
+                    poolOfParagraphs = [...paragraphsMatchingCriteria];
+                } else {
+                    poolOfParagraphs = paragraphsMatchingCriteria.filter(p => !answeredParagraphIds.has(p.id.toString()));
+                }
+                setParagraphsAvailableToPlay(poolOfParagraphs.length);
+
+                // 6. Seleziona i paragrafi per la sessione corrente
+                const shuffledPool = poolOfParagraphs.sort(() => 0.5 - Math.random());
+                const sessionParagraphs = shuffledPool.slice(0, Math.min(numQuestions ?? 1, poolOfParagraphs.length)); // Assicura di non chiedere più del disponibile
+                setParagraphs(sessionParagraphs);
+
+                // Filtra le domande (sub-questions) corrispondenti ai paragrafi selezionati per la sessione
+                const selectedParagraphIds = sessionParagraphs.map(p => p.id);
+                const sessionSubQuestions = currentTodosQuestions.filter(q => selectedParagraphIds.includes(q.paragraphId));
+                setQuestions(sessionSubQuestions);
+
+                // Resetta stati per la nuova sessione
+                setUserAnswers({});
+                setStartTime(Date.now());
+                setCurrentParagraphIndex(0);
+                setScore(0);
+                setShowResults(false);
+                setQuizFinished(false);
+                setTimer(60);
+
             } catch (err) {
-                setError('Errore nel caricamento dei dati. Per favore, riprova.');
-                console.error('Errore nel recupero dei dati:', err);
+                console.error('Errore nel caricamento o filtraggio dei dati per Parrafo:', err);
+                setError('Errore nel caricamento dei paragrafi. Riprova.');
             } finally {
                 setLoading(false);
             }
         };
-        loadData();
-    }, []);
-    // Filtra e seleziona paragrafi e domande
-    useEffect(() => {
-        if (todosParagraphs.length > 0) {
-            let availableParagraphs = [...todosParagraphs];
-            if (respuestas.length > 0) {
-                // Filtra i paragrafi non ancora risposti
-                const respuestasIds = respuestas.map(r => r.idPregunta);
-                availableParagraphs = availableParagraphs.filter(p => !respuestasIds.includes(p.id));
-            }
-            setPreguntasQuedan(availableParagraphs.length);
-            console.log("Quedan preguntas: ", availableParagraphs.length);
-            // Seleziona casualmente i paragrafi non risposti
-            const filteredParagraphs = availableParagraphs
-                .sort(() => 0.5 - Math.random())
-                .slice(0, numQuestions);
-            setParagraphs(filteredParagraphs);
 
-            // Filtra le domande corrispondenti ai paragrafi selezionati
-            const selectedParagraphIds = filteredParagraphs.map(p => p.id);
-            const filteredQuestions = todosQuestions.filter(q => selectedParagraphIds.includes(q.paragraphId));
-            setQuestions(filteredQuestions);
+        loadAndFilterData();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [numQuestions, difficulty, includePreviouslyAnswered, usuario?.id]); // Nota: difficulty non è usata per filtrare i paragrafi attualmente
 
-            setUserAnswers({});
-            setStartTime(Date.now());
-            setCurrentParagraphIndex(0);
-        }
-    }, [todosParagraphs, todosQuestions, respuestas]);
 
     const currentParagraph = paragraphs[currentParagraphIndex];
     const currentQuestions = questions.filter(q => q.paragraphId === currentParagraph?.id);
 
     useEffect(() => {
-        if (!showResults && !quizFinished) {
+        if (!showResults && !quizFinished && currentParagraph) { // Aggiunto currentParagraph per evitare errori se non ancora caricato
             const countdown = setInterval(() => {
                 setTimer((prevTimer) => {
                     if (prevTimer === 1) {
@@ -170,51 +195,82 @@ const ItalianLearningApp: React.FC<QuizParams> = ({
                 correctAnswers++;
                 respuesta.correcta = true;
             } else respuesta.correcta = false;
-            guardarRespuesta(respuesta);
+            if (saveResults && usuario?.id) { // Condiziona il salvataggio della singola risposta
+                guardarRespuesta(respuesta);
+            }
         });
 
         setScore(prevScore => prevScore + correctAnswers);
-        setTotalAnsweredQuestions(prev => prev + currentQuestions.length);
+        setTotalAnsweredQuestions(prev => prev + currentQuestions.length); // Questo conta i blank, non i paragrafi
         setShowResults(true);
     }
 
     const handleNextParagraph = () => {
         if (reviewMode) return;
-        if (!showResults) {
+        if (!showResults && currentParagraph) { // Assicurati che ci sia un currentParagraph prima di verificare
             handleVerify();
         }
         setCurrentParagraphIndex(prev => {
             const nextIndex = prev + 1;
-            if (nextIndex >= numQuestions) {
+            if (nextIndex >= paragraphs.length) { // Usa paragraphs.length (paragrafi della sessione)
                 setQuizFinished(true);
                 setEndTime(Date.now());
-                saveResult();
+                // saveResult sarà chiamato da useEffect dipendente da quizFinished
                 return prev;
             } else {
                 setShowResults(false);
-                //setUserAnswers({});
                 setTimer(60);
                 return nextIndex;
             }
         });
     };
 
-    const saveResult = () => {
-        const result = {
-            name,
-            score,
-            totalQuestions: totalAnsweredQuestions,
-            difficulty,
-            date: new Date().toLocaleString(),
-            userAnswers: userAnswers,
-            paragraphs: paragraphs,
-            questions: questions
-        };
-        localStorage.setItem('quizResult', JSON.stringify(result));
-        console.log('Risultato salvato:', result);
-    };
+    // useEffect per chiamare saveResult quando quizFinished e saveResults sono true
+    useEffect(() => {
+        if (quizFinished && saveResults) {
+            if (!usuario || !usuario.id) {
+                console.warn("Salvataggio risultato sessione (Parrafo): ID utente non disponibile.");
+                const localResult = { name, score, totalAnsweredQuestions, difficulty, date: new Date().toLocaleString(), timeTakenSeconds: startTime && endTime ? (endTime - startTime) / 1000 : undefined, };
+                console.log('Risultato sessione Parrafo (locale, utente non definito):', localResult);
+                localStorage.setItem('paragraphReviewData', JSON.stringify({ userAnswers, paragraphs, questions }));
+                return;
+            }
+
+            const gameSession: GameSessionResult = {
+                userId: usuario.id,
+                gameType: 'ParagraphCompletion',
+                timestamp: new Date(),
+                difficulty: difficulty, // difficulty della sessione generale
+                score: score, // Punteggio basato sui blank corretti
+                totalPossibleScore: totalAnsweredQuestions, // Totale blanks presentati
+                itemsPlayed: paragraphs.length, // Numero di paragrafi effettivamente giocati
+                timeTakenSeconds: startTime && endTime ? Math.round((endTime - startTime) / 1000) : undefined,
+                gameSpecificDetails: {
+                    useDropdown: useDropdown,
+                    includePreviouslyAnswered: includePreviouslyAnswered,
+                    // paragraphIds: paragraphs.map(p => p.id), // Opzionale: ID dei paragrafi giocati
+                }
+            };
+            saveGameSessionResult(gameSession);
+            console.log('Risultato sessione Parrafo inviato a Firebase:', gameSession);
+
+            const reviewData = { userAnswers, paragraphs, questions };
+            localStorage.setItem('paragraphReviewData', JSON.stringify(reviewData));
+
+        } else if (quizFinished && !saveResults) {
+            console.log("Completamento Paragrafo terminato, risultati non salvati per scelta dell'utente.");
+            // Salva comunque i dati per la review locale se necessario
+            const reviewData = { userAnswers, paragraphs, questions };
+            localStorage.setItem('paragraphReviewData', JSON.stringify(reviewData));
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [quizFinished, saveResults]);
+
+
     const startReview = () => {
-        const savedResult = JSON.parse(localStorage.getItem('quizResult') || '{}');
+        // Prova a caricare da 'paragraphReviewData'. Se non c'è, prova col vecchio 'quizResult' per retrocompatibilità.
+        const reviewDataString = localStorage.getItem('paragraphReviewData') || localStorage.getItem('quizResult');
+        const savedResult = JSON.parse(reviewDataString || '{}');
         setParagraphs(savedResult.paragraphs || []);
         setQuestions(savedResult.questions || []);
         setUserAnswers(savedResult.userAnswers || {});
@@ -278,9 +334,14 @@ const ItalianLearningApp: React.FC<QuizParams> = ({
                     <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700">
                         Riprova con Nuove Domande
                     </Button>
-                    <Button onClick={startReview} className="w-full bg-blue-500 hover:bg-blue-700 mt-4">
+                    <Button onClick={startReview} className="w-full bg-blue-500 hover:bg-blue-700 mt-2">
                         Rivedi le risposte
                     </Button>
+                    {onExit && (
+                        <Button onClick={onExit} className="w-full bg-gray-500 hover:bg-gray-700 text-white mt-2">
+                            Torna al Menu Principale
+                        </Button>
+                    )}
                 </CardActions>
             </ResponsiveCard>
         );
@@ -316,9 +377,14 @@ const ItalianLearningApp: React.FC<QuizParams> = ({
                             </div>
                         );
                     })}
-                    <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700 mt-4">
-                        Torna alla Pagina Iniziale
+                    <Button onClick={() => window.location.reload()} className="w-full bg-blue-500 hover:bg-blue-700 mt-4 mb-2">
+                        Pagina Iniziale (Ricarica)
                     </Button>
+                    {onExit && (
+                        <Button onClick={onExit} className="w-full bg-gray-500 hover:bg-gray-700 text-white">
+                            Torna al Menu Principale
+                        </Button>
+                    )}
                 </CardContent>
             </ResponsiveCard>
         );
@@ -389,6 +455,13 @@ const ItalianLearningApp: React.FC<QuizParams> = ({
                         ))}
                         <Button onClick={handleNextParagraph} className="mt-4 bg-green-500 hover:bg-green-700">
                             {currentParagraphIndex === numQuestions - 1 ? "Termina il quiz" : "Prossimo paragrafo"}
+                        </Button>
+                    </div>
+                )}
+                {onExit && !showResults && !quizFinished && (
+                    <div className="flex justify-center mt-4">
+                        <Button onClick={onExit} variant="outlined" size="small">
+                            Torna al Menu Principale
                         </Button>
                     </div>
                 )}


### PR DESCRIPTION
Introduces new global options for users:
1.  Save Results: Allows users to choose whether to save their game session results and individual answers to Firebase.
2.  Include Previously Answered Questions: Allows users to include questions/items they have encountered in past sessions.

Key changes:
- Added checkboxes in the main settings UI (AppIniziale) for these options.
- Implemented `fetchAnsweredQuestionIdsGroupedByType` to efficiently retrieve IDs of previously answered items.
- Updated all relevant game components (QuizItalianoGPT, ParagraphCompletion, Hangman, ErrorDetection) to:
    - Fetch and filter questions/items based on the new options.
    - Display detailed counts (total possible, answered, available).
    - Conditionally save game data based on user's preference.
- ItalianTypingTutor now also respects the "Save Results" option.